### PR TITLE
Expose findOther function

### DIFF
--- a/lua/other-nvim/init.lua
+++ b/lua/other-nvim/init.lua
@@ -196,4 +196,8 @@ M.clear = function()
 	vim.b.onv_otherFile = nil
 end
 
+M.findOther = function(context)
+        return findOther(vim.api.nvim_buf_get_name(0), context or nil)
+end
+
 return M


### PR DESCRIPTION
This helps me integrate with `vim-test`, I have made a PR to allow to use a function to determine the test file (https://github.com/vim-test/vim-test/pull/665)
Maybe somebody will find this useful :shrug: 

This is how it's used: 
```lua
      vim.g["test#custom_alternate_file"] = function()
        local other = require("other-nvim")
        local other_file = other.findOther("test")[1]

        if other_file then
          return other_file.filename
        else
          return ""
        end
      end
```