### PR TITLE
Modify Angular mappings to include filename

### DIFF
--- a/lua/other-nvim/builtin/mappings/angular.lua
+++ b/lua/other-nvim/builtin/mappings/angular.lua
@@ -1,68 +1,68 @@
 return {
 	{
-		pattern = "/(.*)/(.*)/.*.ts$",
+		pattern = "/(.*)/(.*)/(.*).ts$",
 		target = {
 			{
-				target = "/%1/%2/%2.component.html",
+				target = "/%1/%2/%3.component.html",
 				context = "html",
 			},
 			{
-				target = "/%1/%2/%2.component.scss",
+				target = "/%1/%2/%3.component.scss",
 				context = "scss",
 			},
 			{
-				target = "/%1/%2/%2.component.spec.ts",
+				target = "/%1/%2/%3.component.spec.ts",
 				context = "test",
 			},
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/.*.html$",
+		pattern = "/(.*)/(.*)/(.*).html$",
 		target = {
 			{
-				target = "/%1/%2/%2.component.ts",
+				target = "/%1/%2/%3.component.ts",
 				context = "component",
 			},
 			{
-				target = "/%1/%2/%2.component.scss",
+				target = "/%1/%2/%3.component.scss",
 				context = "scss",
 			},
 			{
-				target = "/%1/%2/%2.component.spec.ts",
+				target = "/%1/%2/%3.component.spec.ts",
 				context = "test",
 			},
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/.*.scss$",
+		pattern = "/(.*)/(.*)/(.*).scss$",
 		target = {
 			{
-				target = "/%1/%2/%2.component.html",
+				target = "/%1/%2/%3.component.html",
 				context = "html",
 			},
 			{
-				target = "/%1/%2/%2.component.ts",
+				target = "/%1/%2/%3.component.ts",
 				context = "component",
 			},
 			{
-				target = "/%1/%2/%2.component.spec.ts",
+				target = "/%1/%2/%3.component.spec.ts",
 				context = "test",
 			},
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/.*.spec.ts$",
+		pattern = "/(.*)/(.*)/(.*).spec.ts$",
 		target = {
 			{
-				target = "/%1/%2/%2.component.html",
+				target = "/%1/%2/%3.component.html",
 				context = "html",
 			},
 			{
-				target = "/%1/%2/%2.component.scss",
+				target = "/%1/%2/%3.component.scss",
 				context = "scss",
 			},
 			{
-				target = "/%1/%2/%2.component.ts",
+				target = "/%1/%2/%3.component.ts",
 				context = "component",
 			},
 		},

--- a/lua/other-nvim/builtin/mappings/angular.lua
+++ b/lua/other-nvim/builtin/mappings/angular.lua
@@ -1,6 +1,6 @@
 return {
 	{
-		pattern = "/(.*)/(.*)/(.*).ts$",
+		pattern = "/(.*)/(.*)/([a-zA-Z-_]*).*.ts$",
 		target = {
 			{
 				target = "/%1/%2/%3.component.html",
@@ -17,7 +17,7 @@ return {
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/(.*).html$",
+		pattern = "/(.*)/(.*)/([a-zA-Z-_]*).*html$",
 		target = {
 			{
 				target = "/%1/%2/%3.component.ts",
@@ -34,7 +34,7 @@ return {
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/(.*).scss$",
+		pattern = "/(.*)/(.*)/([a-zA-Z-_]*).*scss$",
 		target = {
 			{
 				target = "/%1/%2/%3.component.html",
@@ -51,7 +51,7 @@ return {
 		},
 	},
 	{
-		pattern = "/(.*)/(.*)/(.*).spec.ts$",
+		pattern = "/(.*)/(.*)/([a-zA-Z-_]*).*spec.ts$",
 		target = {
 			{
 				target = "/%1/%2/%3.component.html",


### PR DESCRIPTION
I've worked on multiple projects where the filename would not necessarily match the directory name.

For example, the current builtin angular mappings assume the following structure:
```
foo/
- foo.component.ts
- foo.component.html
- foo.component.spec.ts
```

But, this is ofcourse perfectly valid:

```
containers/
- foo/
- - foo-container.component.ts
- - foo-container.component.html
- - foo-container.component.spec.ts
```

I've modified the builtin mappings to include the current filename (excluding any `.component` in it). I've tested in on my personal project (with both `foo.component.ts` as `foo-container.component.ts`).