### PR TITLE
Fix : Escape patterns when removing current working directory from filenames

### DIFF
--- a/lua/other-nvim/helper/window.lua
+++ b/lua/other-nvim/helper/window.lua
@@ -134,7 +134,9 @@ local function _prepareLines(files)
 	for k, file in pairs(files) do
 		local filename = file.filename
 		local fileNotExistsMarker = (not file.exists and newFileIndicator .. " " or "")
-		filename = filename:gsub(vim.fn.getcwd() .. "/", "")
+		local cwd = vim.fn.getcwd()
+
+		filename = filename:gsub(util.escape_pattern(cwd) .. "/*", "")
 		filename = fileNotExistsMarker .. filename
 
 		local context = file.context or ""


### PR DESCRIPTION
Hi, thanks for the plugin, I've been using it for about a week and I really like it 🥇 

This PR should fix a small bug I encountered :

If the current directory has characters used in lua pattern matching, it won't be removed when displaying filenames.
For exemple, if my current working directory is something like `Users/jeanne/my-directory/` this will be displayed :
```
  a  | test       | Users/jeanne/my-directory/spec/models/user_spec.rb  
  d  | controller | Users/jeanne/my-directory/app/controllers/users_controller.rb  
```
 Instead of : 
 ```
  a  | test       | spec/models/user_spec.rb  
  d  | controller | app/controllers/users_controller.rb  
  ```
  if my current directory is `Users/jeanne/mydirectory`
